### PR TITLE
Add recommendation button

### DIFF
--- a/components/ItemContent.tsx
+++ b/components/ItemContent.tsx
@@ -31,6 +31,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Platform, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AddToFavorites } from "./AddToFavorites";
+import { RecommendItemButton } from "./RecommendItemButton";
 import { ItemHeader } from "./ItemHeader";
 import { ItemTechnicalDetails } from "./ItemTechnicalDetails";
 import { MediaSourceSelector } from "./MediaSourceSelector";
@@ -107,6 +108,7 @@ export const ItemContent: React.FC<{ item: BaseItemDto }> = React.memo(
 
                     <PlayedStatus items={[item]} size='large' />
                     <AddToFavorites item={item} />
+                    <RecommendItemButton item={item} size='large' />
                   </View>
                 )}
               </View>

--- a/components/RecommendItemButton.tsx
+++ b/components/RecommendItemButton.tsx
@@ -1,0 +1,146 @@
+import { Loader } from "@/components/Loader";
+import { RoundButton } from "@/components/RoundButton";
+import { Text } from "@/components/common/Text";
+import { useUsers } from "@/hooks/useUsers";
+import { apiAtom, userAtom } from "@/providers/JellyfinProvider";
+import type { BaseItemDto } from "@jellyfin/sdk/lib/generated-client";
+import { useAtomValue } from "jotai";
+import React, { useState } from "react";
+import {
+  FlatList,
+  Modal,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { toast } from "sonner-native";
+
+interface Props extends React.ComponentProps<typeof View> {
+  item: BaseItemDto;
+  size?: "default" | "large";
+}
+
+export const RecommendItemButton: React.FC<Props> = ({ item, size, ...props }) => {
+  const api = useAtomValue(apiAtom);
+  const currentUser = useAtomValue(userAtom);
+  const { data: users = [], isLoading } = useUsers();
+  const [modalVisible, setModalVisible] = useState(false);
+
+  const sendRecommendation = async (userId: string) => {
+    if (!api || !item.Id) return;
+    try {
+      await api.post("/Streamyfin/recommend", {
+        itemId: item.Id,
+        toUserId: userId,
+        fromUserId: currentUser?.Id,
+      });
+      toast.success("Recommendation sent");
+    } catch (error) {
+      toast.error("Failed to send recommendation");
+    } finally {
+      setModalVisible(false);
+    }
+  };
+
+  return (
+    <View {...props}>
+      <RoundButton icon='send' onPress={() => setModalVisible(true)} size={size} />
+
+      <Modal
+        animationType='slide'
+        transparent
+        visible={modalVisible}
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <View style={styles.centeredView}>
+          <View style={styles.modalView}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Select User</Text>
+              <TouchableOpacity onPress={() => setModalVisible(false)}>
+                <Ionicons name='close' size={24} color='white' />
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.modalContent}>
+              {isLoading ? (
+                <View style={styles.loadingContainer}>
+                  <Loader />
+                </View>
+              ) : (
+                <FlatList
+                  data={users.filter((u) => u.Id !== currentUser?.Id)}
+                  keyExtractor={(u) => u.Id || ""}
+                  renderItem={({ item: u }) => (
+                    <TouchableOpacity
+                      style={styles.userItem}
+                      onPress={() => u.Id && sendRecommendation(u.Id)}
+                    >
+                      <Text style={styles.userName}>{u.Name}</Text>
+                    </TouchableOpacity>
+                  )}
+                  contentContainerStyle={styles.listContent}
+                />
+              )}
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  centeredView: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
+  },
+  modalView: {
+    width: "90%",
+    maxHeight: "80%",
+    backgroundColor: "#1c1c1c",
+    borderRadius: 20,
+    overflow: "hidden",
+    display: "flex",
+    flexDirection: "column",
+  },
+  modalHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#333",
+  },
+  modalContent: {
+    flex: 1,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  loadingContainer: {
+    padding: 40,
+    alignItems: "center",
+  },
+  listContent: {
+    paddingVertical: 8,
+  },
+  userItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#333",
+  },
+  userName: {
+    fontSize: 16,
+    fontWeight: "500",
+    color: "white",
+  },
+});

--- a/hooks/useUsers.ts
+++ b/hooks/useUsers.ts
@@ -1,0 +1,19 @@
+import { apiAtom } from "@/providers/JellyfinProvider";
+import { getUserApi } from "@jellyfin/sdk/lib/utils/api";
+import { useQuery } from "@tanstack/react-query";
+import { useAtom } from "jotai";
+import type { UserDto } from "@jellyfin/sdk/lib/generated-client/models";
+
+export const useUsers = () => {
+  const [api] = useAtom(apiAtom);
+
+  return useQuery({
+    queryKey: ["users"],
+    queryFn: async (): Promise<UserDto[]> => {
+      if (!api) return [];
+      const res = await getUserApi(api).getUsers();
+      return res.data ?? [];
+    },
+    enabled: !!api,
+  });
+};

--- a/translations/en.json
+++ b/translations/en.json
@@ -407,6 +407,7 @@
     "appeared_in": "Appeared in",
     "could_not_load_item": "Could not load item",
     "none": "None",
+    "recommend_button": "Recommend",
     "download": {
       "download_season": "Download Season",
       "download_series": "Download Series",
@@ -416,6 +417,10 @@
       "download_button": "Download",
       "using_optimized_server": "Using optimized server",
       "using_default_method": "Using default method"
+    },
+    "toasts": {
+      "recommendation_sent": "Recommendation sent",
+      "recommendation_failed": "Failed to send recommendation"
     }
   },
   "live_tv": {


### PR DESCRIPTION
## Summary
- fetch list of Jellyfin users
- allow recommending items to other users
- wire up Recommend button in item view
- add translations for recommendations

## Testing
- `bun run lint` *(fails: biome not found)*
- `bun run check` *(fails: biome not found)*
- `npm test` *(fails: Missing script & npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857025c652483289491a181602c9be5